### PR TITLE
Adapt socket add matchmaker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
 
 [[package]]
 name = "idna"
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -289,9 +289,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "log"
@@ -305,7 +305,7 @@ dependencies = [
 [[package]]
 name = "macroquad"
 version = "0.3.0-alpha.17"
-source = "git+https://github.com/not-fl3/macroquad.git#278990615d55d33fc3fbfe24713cf2db5cf5a5b2"
+source = "git+https://github.com/not-fl3/macroquad.git#8b3e25762d8f83e0a38dfa3ae944f50f594117df"
 dependencies = [
  "bumpalo",
  "fontdue",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "macroquad-particles"
 version = "0.1.0"
-source = "git+https://github.com/not-fl3/macroquad.git#278990615d55d33fc3fbfe24713cf2db5cf5a5b2"
+source = "git+https://github.com/not-fl3/macroquad.git#8b3e25762d8f83e0a38dfa3ae944f50f594117df"
 dependencies = [
  "macroquad",
  "nanoserde",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "macroquad-tiled"
 version = "0.1.0"
-source = "git+https://github.com/not-fl3/macroquad.git#278990615d55d33fc3fbfe24713cf2db5cf5a5b2"
+source = "git+https://github.com/not-fl3/macroquad.git#8b3e25762d8f83e0a38dfa3ae944f50f594117df"
 dependencies = [
  "macroquad",
  "nanoserde",
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "macroquad_macro"
 version = "0.1.2"
-source = "git+https://github.com/not-fl3/macroquad.git#278990615d55d33fc3fbfe24713cf2db5cf5a5b2"
+source = "git+https://github.com/not-fl3/macroquad.git#8b3e25762d8f83e0a38dfa3ae944f50f594117df"
 
 [[package]]
 name = "matches"
@@ -415,7 +415,7 @@ dependencies = [
 [[package]]
 name = "nakama-rs"
 version = "0.1.0"
-source = "git+https://github.com/not-fl3/nakama-rs.git#f8df6d0f2677d0c8dfe1cd15c06c3a0126aa96ef"
+source = "git+https://github.com/not-fl3/nakama-rs.git#29f55616f1ca3060b81b38843699807c11e9fb95"
 dependencies = [
  "base64",
  "nanoserde",
@@ -537,7 +537,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "physics-platformer"
 version = "0.1.0"
-source = "git+https://github.com/not-fl3/macroquad.git#278990615d55d33fc3fbfe24713cf2db5cf5a5b2"
+source = "git+https://github.com/not-fl3/macroquad.git#8b3e25762d8f83e0a38dfa3ae944f50f594117df"
 dependencies = [
  "macroquad",
 ]
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -572,12 +572,13 @@ dependencies = [
 [[package]]
 name = "quad-net"
 version = "0.1.1"
-source = "git+https://github.com/not-fl3/quad-net.git#912ff4e9e0ce6d94d2cca2081abd632f132c8d72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b697fe4057cb8a40c8822fa0ad8ecc999be6acb70a2b36cbcf1fba51e42f190"
 dependencies = [
  "nanoserde",
+ "qws",
  "sapp-jsutils",
  "ureq",
- "ws",
 ]
 
 [[package]]
@@ -593,6 +594,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "qws"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f10552d7fceaaba721fc04a0971d8b78021c78119231a09a8a3778aca55f08"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "httparse",
+ "log",
+ "mio",
+ "mio-extras",
+ "openssl",
+ "rand",
+ "sha1",
+ "slab",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -728,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -756,9 +776,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -767,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -788,9 +808,9 @@ checksum = "7622061403fd00f0820df288e5a580e87d3ce15a1c4313c59fd1ffb77129903f"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -869,9 +889,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -879,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -894,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -904,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -917,15 +937,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -943,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]
@@ -983,24 +1003,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "ws"
-version = "0.7.9"
-source = "git+https://github.com/not-fl3/ws-rs.git#9f5fbdc85fb00edad96c9401d28ab2c12d586185"
-dependencies = [
- "byteorder",
- "bytes",
- "httparse",
- "log",
- "mio",
- "mio-extras",
- "openssl",
- "rand",
- "sha1",
- "slab",
- "url 1.7.2",
-]
 
 [[package]]
 name = "ws2_32-sys"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -8,7 +8,10 @@ use macroquad::{
     window::{clear_background, next_frame, screen_height, screen_width},
 };
 
-use crate::nakama::ApiClient;
+use crate::nakama::{
+    matchmaker::{Matchmaker, QueryItemBuilder},
+    ApiClient,
+};
 
 const WINDOW_WIDTH: f32 = 700.0;
 const WINDOW_HEIGHT: f32 = 300.0;
@@ -405,12 +408,19 @@ pub async fn matchmaking_lobby() -> Scene {
                             .ui(ui, &mut maximum_players);
 
                         if ui.button(None, "Start matchmaking") {
-                            nakama.socket_add_matchmaker(
-                                minimum_players.parse::<u32>().unwrap(),
-                                maximum_players.parse::<u32>().unwrap(),
-                                "+properties.engine:\\\"macroquad_matchmaking\\\"",
-                                "{\"engine\":\"macroquad_matchmaking\"}",
-                            );
+                            let mut matchmaker = Matchmaker::new();
+                            matchmaker
+                                .min(minimum_players.parse::<u32>().unwrap())
+                                .max(maximum_players.parse::<u32>().unwrap())
+                                .add_string_property("engine", "macroquad_matchmaking")
+                                .add_query_item(
+                                    &QueryItemBuilder::new("engine")
+                                        .required()
+                                        .term("macroquad_matchmaking")
+                                        .build(),
+                                );
+
+                            nakama.socket_add_matchmaker(&matchmaker);
 
                             next_scene = Some(Scene::WaitingForMatchmaking { private: false });
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,10 @@ pub mod consts {
 }
 
 pub mod nakama {
-    pub use nakama_rs::api_client::{ApiClient, Event};
+    pub use nakama_rs::{
+        api_client::{ApiClient, Event},
+        matchmaker,
+    };
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
- Adapt socket_add_matchmaker to the latest changes in `nakama-rs`
- Updated dependencies so that nakama-rs points to master by running `cargo update`