### PR TITLE
Increase token expiry to 7 days

### DIFF
--- a/docker/config.yml
+++ b/docker/config.yml
@@ -1,0 +1,2 @@
+session:
+  token_expiry_sec: 604800

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "-ecx"
       - >
           /nakama/nakama migrate up --database.address root@cockroachdb:26257 &&
-          exec /nakama/nakama --name nakama1 --database.address root@cockroachdb:26257 --logger.level debug
+          exec /nakama/nakama --name nakama1 --database.address root@cockroachdb:26257 --logger.level debug --config /nakama/data/config.yml
     restart: always
     links:
       - "cockroachdb:db"


### PR DESCRIPTION
Increase token expiry to 7 days to avoid network requests failing after 60 seconds.